### PR TITLE
removed overlapping general proficiency marking for new items

### DIFF
--- a/.github/ChangeLog.md
+++ b/.github/ChangeLog.md
@@ -79,3 +79,6 @@
 - A few fixes for Open Wounds and Great Wounds not correctly displaying/calculating 
 - Added Self-Repair as an example of Rengeration 
 - Added ui notification for legendary action recharge
+
+###1.8.2
+- Removed overlapping proficiency marking with the latest dnd5e 1.2.0 system. No backwards compat provided for <1.2.0.  Retains specific proficiency marking like "Daggers" or "Longswords".


### PR DESCRIPTION
This is a stepping stone for providing a PR for dnd5e core system to implement specific proficiency marking in addition to the already present generic proficiency marking.