### PR TITLE
* Feature #87 Hide NPC names for Open/Great Wound saves

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -176,6 +176,10 @@
     "DND5EH.OpenWoundDebug_name":"Debugging",
     "DND5EH.OpenWoundDebug_hint":"Adds a few console logs for debugging purposes",
 
+    "DND5EH.GreatAndOpenWoundMaskNPC_name": "Hide GM info from Great Wound and Open Wound report",
+    "DND5EH.GreatAndOpenWoundMaskNPC_hint": "Replaces uses of the NPC's name with \"A creature\" when reporting",
+    "DND5EH.GreatAndOpenWoundMaskNPC_mask": "a creature",
+
     "DND5EH.Hooks_preUpdateActor_updatelog" : "Dnd5e Helpers: {actorName}'s update contains hp: {hp}, spells: {spells}",
     "DND5EH.Hooks_updateActor_updatelog" :"Dnd5e Helpers: {currentTokenName}'s update contains regen: {regenSett}",
     "DND5EH.Hooks_preupdateToken_updatelog" : "Dnd5e Helpers: {ActorName}'s update contains hp: {hp}, and Fort: {fortSett}"

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -173,6 +173,10 @@
     "DND5EH.OpenWoundDebug_name":"Debugging",
     "DND5EH.OpenWoundDebug_hint":"Ajoute quelques journaux de console à des fins de débogage",
 
+    "DND5EH.GreatAndOpenWoundMaskNPC_name": "[EN] Hide GM info from Great Wound and Open Wound report",
+    "DND5EH.GreatAndOpenWoundMaskNPC_hint": "[EN] Replaces uses of the NPC's name with \"A creature\" when reporting",
+    "DND5EH.GreatAndOpenWoundMaskNPC_mask": "[EN] a creature",
+
     "DND5EH.Hooks_preUpdateActor_updatelog" : "Aide Dnd5e : La mise à jour de {actorName} concerne ses PV {hp}, Sorts: {spells}",
     "DND5EH.Hooks_updateActor_updatelog" :"Aide Dnd5e: La mise à jour de {currentTokenName} concerne sa regénération: {regenSett}",
     "DND5EH.Hooks_preupdateToken_updatelog" : "Aide Dnd5e: La mise à jour de {ActorName} concerne ses PV : {hp}, and Fort: {fortSett}"

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -173,6 +173,10 @@
     "DND5EH.OpenWoundDebug_name":"デバッグ",
     "DND5EH.OpenWoundDebug_hint":"いくつかのコンソールログをデバッグ用に追加します。",
 
+    "DND5EH.GreatAndOpenWoundMaskNPC_name": "[EN] Hide GM info from Great Wound and Open Wound report",
+    "DND5EH.GreatAndOpenWoundMaskNPC_hint": "[EN] Replaces uses of the NPC's name with \"A creature\" when reporting",
+    "DND5EH.GreatAndOpenWoundMaskNPC_mask": "[EN] a creature",
+
     "DND5EH.Hooks_preUpdateActor_updatelog" : "DnD5e Helpers：{actorName}のアップデートは hp：{hp}と呪文：{spells}を含みます。",
     "DND5EH.Hooks_updateActor_updatelog" :"DnD5e Helpers：{currentTokenName}のアップデートは リジェネ：{regenSett}を含みます。",
     "DND5EH.Hooks_preupdateToken_updatelog" : "DnD5e Helpers：{ActorName}のアップデートは hp：{hp} と しぶとさ：{fortSett}を含みます。"

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -173,6 +173,10 @@
     "DND5EH.OpenWoundDebug_name":"디버깅",
     "DND5EH.OpenWoundDebug_hint":"디버깅을 위해 몇 개의 콘솔 로그를 추가합니다.",
 
+    "DND5EH.GreatAndOpenWoundMaskNPC_name": "[EN] Hide GM info from Great Wound and Open Wound report",
+    "DND5EH.GreatAndOpenWoundMaskNPC_hint": "[EN] Replaces uses of the NPC's name with \"A creature\" when reporting",
+    "DND5EH.GreatAndOpenWoundMaskNPC_mask": "[EN] a creature",
+
     "DND5EH.Hooks_preUpdateActor_updatelog" : "Dnd5e Helpers: {actorName} 액터의 업데이트에 다음이 포함되었습니다. hp: {hp}, spells: {spells}",
     "DND5EH.Hooks_updateActor_updatelog" :"Dnd5e Helpers: {currentTokenName} 대상의 업데이트에 다음이 포함되었습니다. regen: {regenSett}",
     "DND5EH.Hooks_preupdateToken_updatelog" : "Dnd5e Helpers: {ActorName} 액터의 업데이트에 다음이 포함되었습니다. hp: {hp}, and Fort: {fortSett}"

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -31,14 +31,14 @@
     "DND5EH.LoS_providescover":"Fornece Cobertura",
     "DND5EH.LoSMaskNPCs_sourceMask": "Outra criatura está no caminho.",
     "DND5EH.LoSMaskNPCs_targetMask": "uma criatura",
-    "DND5EH.LoSKeybind_name" : "[EN] Keybind for Cover",
-    "DND5EH.LoSKeybind_hint" : "[EN] Assign a keyboard shortcut to check cover when targeting.",
+    "DND5EH.LoSKeybind_name" : "Atalho para Cobertura",
+    "DND5EH.LoSKeybind_hint" : "Configura um atalho do teclado para a checagem de cobertura do alvo ao mirar",
 
-    "DND5EH.LoSCover_name" : "[EN] Cover Application",
-    "DND5EH.LoSCover_hint" : "[EN] Allow application of cover bonuses. These are applied to the attacker, not the target. These only affect ranged weapon attacks, not dexterity saves",
-    "DND5EH.LoSCover_manual" : "[EN] Manual",
-    "DND5EH.LoSCover_auto" : "[EN] Automatic",
-    "DND5EH.LoSCover_cover" : "[EN] cover",
+    "DND5EH.LoSCover_name" : "Aplicação de Cobertura",
+    "DND5EH.LoSCover_hint" : "Permite aplicar bônus de cobertura. Estes são aplicados no atacante, não no alvo. E afeta somente armas ataque a distância, não salvaguarda de destreza.",
+    "DND5EH.LoSCover_manual" : "Manual",
+    "DND5EH.LoSCover_auto" : "Automática",
+    "DND5EH.LoSCover_cover" : "Cobertura",
 
     "DND5EH.LoSWithTokens_name":"Considerar tokens interpostos como cobertura parcial",
     "DND5EH.LoSWithTokens_hint": "Se desabilitado, resulta em tokens não serem considerados para o cálculo de cobertura.",
@@ -172,6 +172,10 @@
 
     "DND5EH.OpenWoundDebug_name":"Debugging",
     "DND5EH.OpenWoundDebug_hint":"Adiciona alguns logs no console para propósito de debugging.",
+
+    "DND5EH.GreatAndOpenWoundMaskNPC_name": "Ocultar informações do MJ ao relatar Dano Maciço e Lesão Persistente",
+    "DND5EH.GreatAndOpenWoundMaskNPC_hint": "Substitui nomes de PdM com \"Uma criatura\" no relato",
+    "DND5EH.GreatAndOpenWoundMaskNPC_mask": "uma criatura",
 
     "DND5EH.Hooks_preUpdateActor_updatelog" : "DnD5e Helpers: A atualização de {actorName} tem PV: {hp}, magias: {spells}",
     "DND5EH.Hooks_updateActor_updatelog" :"DnD5e Helpers: A atualização de {currentTokenName} tem regen: {regenSett}",


### PR DESCRIPTION
    * This feature addes a saninitzeName() method as helper.
    The method uses the flag (enable/disable) to use the i18n definition
    to mask the NPC name.

    * Used that on Open/Great Wound and also in Cover calculations.

    * Added the new setting and all base i18n fields.

    * Translated the pt-BR.json and also added some extra.