### PR TITLE
Fix for cover message always sending to other players

### DIFF
--- a/scripts/dnd5e-helpers.js
+++ b/scripts/dnd5e-helpers.js
@@ -2637,7 +2637,7 @@ class CoverData {
       }
       /** whisper the message if we are being a cautious GM */
       let recipients;
-      if (game.user.isGM && game.settings.get('dnd5e-helpers', 'losMaskNPCs')) {
+      if (game.settings.get('dnd5e-helpers', 'losMaskNPCs')) {
         recipients = ChatMessage.getWhisperRecipients('GM')
 
       } else {


### PR DESCRIPTION
Reference #112 
Current issue:
Login on foundry as 3 users (GM, User 1, User 2).
Try to mark a creature as User 1 with Hide GM info from Cover Report ON
What you expect: 
Only the GM and the player that checked the cover should get the message.
What happens:
GM, User 1 and User 2 get the cover info, and if User 2 tries clicking the cover buttons, an error about lacking permission to the message appears.

This check is false for all the users except for the GM, which causes the else statement to execute for them.