### PR TITLE
Create feature to handle sorcery point conversion

### DIFF
--- a/scripts/dnd5e-helpers.js
+++ b/scripts/dnd5e-helpers.js
@@ -1086,16 +1086,9 @@ Hooks.on("updateCombat", async (combat, changed, options, userId) => {
 
     /** begin removal logic for the _next_ token */
     const nextTurn = combat.turns[changed.turn];
-    /** data structure for 0.6 */
-    let nextTokenId = null;
-    if (getProperty(nextTurn, "tokenId")) {
-      nextTokenId = nextTurn.tokenId;
-    }
-    else {
-      nextTokenId = getProperty(nextTurn, token._id);
-    }
 
-
+    let nextTokenId = nextTurn.data.tokenId;
+  
     let currentToken = canvas.tokens.get(nextTokenId);
 
     /** we dont care about tokens without actors */
@@ -1139,8 +1132,8 @@ Hooks.on("updateCombat", async (combat, changed, options, userId) => {
 /** all preUpdateToken hooks handeled here */
 Hooks.on("preUpdateToken", (scene, tokenData, update, options) => {
   let hp = getProperty(update, "actorData.data.attributes.hp.value");
-  if ((game.settings.get('dnd5e-helpers', 'gwEnable')) && hp !== (null || undefined)) {
-    GreatWound_preUpdateToken(scene, tokenData, update);
+  if ((game.settings.get('dnd5e-helpers', 'gwEnable')) && hp !== (null || undefined || 0)) {
+    GreatWound_preUpdateToken(scene, tokenData.data, update);
   }
 
   let Actor = game.actors.get(tokenData.actorId);
@@ -1154,12 +1147,12 @@ Hooks.on("preUpdateToken", (scene, tokenData, update, options) => {
 
   if (game.settings.get('dnd5e-helpers', 'undeadFort') === "1") {
     if (hp === 0 && fortitudeFeature !== null) {
-      UndeadFortCheckQuick(tokenData, update, options)
+      UndeadFortCheckQuick(tokenData.data, update, options)
     }
   }
   if (game.settings.get('dnd5e-helpers', 'undeadFort') === "2") {
     if (hp === 0 && fortitudeFeature !== null) {
-      UndeadFortCheckSlow(tokenData, update, options)
+      UndeadFortCheckSlow(tokenData.data, update, options)
     }
   }
 });
@@ -1253,55 +1246,46 @@ Hooks.on("deleteCombat", async (combat, settings, id) => {
   }
 });
 
-
+//0.8.0 approved
 /** Measured template 5/5/5 scaling */
-Hooks.on("preCreateMeasuredTemplate", async (scene,template)=>{
-
-
-  /** range 0-3
-   *  b01 = line/cone, 
-   *  b10 = circles,
-   *  b11 = both 
-   */
-  const templateMode = game.settings.get('dnd5e-helpers', 'gridTemplateScaling');
-
-  if (templateMode == 0) {
-    /** template adjusting is not enabled, bail out */
-    return;
-  }
-
-  if (!!(templateMode & 0b01) && (template.t == 'ray' || template.t == 'cone')) {
-    /** scale rays after placement to cover the correct number of squares based on 5e diagonal distance */
-    let diagonalScale = Math.abs(Math.sin(Math.toRadians(template.direction))) +
-      Math.abs(Math.cos(Math.toRadians(template.direction)))
-    template.distance = diagonalScale * template.distance;
-  }
-  else if (!!(templateMode & 0b10) && template.t == 'circle' &&
-    !(template.distance / scene.data.gridDistance < .9)) {
-
-    /** Convert circles to equivalent squares (e.g. fireball is square) 
-     *  if the template is 1 grid unit or larger (allows for small circlar
-     *  templates as temporary "markers" of sorts
+Hooks.on("preCreateMeasuredTemplate", async (scene,templateDocument)=>{
+  let template = templateDocument.data
+  
+    /** range 0-3
+     *  b01 = line/cone, 
+     *  b10 = circles,
+     *  b11 = both 
      */
-
-    /** convert to a rectangle */
-    template.t = 'rect';
-
-    /** convert radius in grid units to radius in pixels */
-    let radiusPx = (template.distance / scene.data.gridDistance) * scene.data.grid;
-
-    /** shift origin to top left in prep for converting to rectangle */
-    template.x -= radiusPx;
-    template.y -= radiusPx;
-
-    /** convert the "distance" to the squares hypotenuse */
-    const length = template.distance * 2;
-    template.distance = Math.hypot(length, length);
-
-    /** always measured top left to bottom right */
-    template.direction = 45;
-  }
-});
+    const templateMode = game.settings.get('dnd5e-helpers', 'gridTemplateScaling');
+  
+    if (templateMode == 0) {
+      /** template adjusting is not enabled, bail out */
+      return;
+    }
+  
+    if (!!(templateMode & 0b01) && (template.t == 'ray' || template.t == 'cone')) {
+      /** scale rays after placement to cover the correct number of squares based on 5e diagonal distance */
+      let diagonalScale = Math.abs(Math.sin(Math.toRadians(template.direction))) +
+        Math.abs(Math.cos(Math.toRadians(template.direction)))
+        templateDocument.data.update({distance : diagonalScale * template.distance})
+    }
+    else if (!!(templateMode & 0b10) && template.t == 'circle' &&
+      !(template.distance / scene.data.gridDistance < .9)) {
+  
+      /** Convert circles to equivalent squares (e.g. fireball is square) 
+       *  if the template is 1 grid unit or larger (allows for small circlar
+       *  templates as temporary "markers" of sorts
+       */
+      /** convert radius in grid units to radius in pixels */
+      let radiusPx = (template.distance / scene.data.gridDistance) * scene.data.grid;
+  
+      /** convert the "distance" to the squares hypotenuse */
+      const length = template.distance * 2;
+      let distance = Math.hypot(length, length);
+  
+      templateDocument.data.update({t: 'rect', x: template.x - radiusPx, y: template.y - radiusPx, distance: distance, direction: 45})
+    }
+  });
     
 
 /**


### PR DESCRIPTION
Adding in new feature to handle the conversion of sorcery points to spell slots and vice versa. 
A pop up menu to handle it maybe. Would also need to add in a way to direct where the sorcery points are being tracked. Most likely in one of the resources. 
Also, find a way to by-pass the wild magic surge when removing spell slots for wild magic sorcerers. 