### PR TITLE
Update module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "name": "dnd5e-helpers",
     "title": "DnD5e Helpers",
     "description": "Little helpers for little tasks.",
-    "systems": ["dnd5e"],
+    "system": ["dnd5e"],
     "version": "3.0.0-alpha",
     "author": "honeybadger, Kandashi, hugoprudente, kekilla",
     "authors": [


### PR DESCRIPTION
vtt logs are throwing warnings about still using systems in modules.json

[warn] Package dnd5e-helpers is using the old "systems" manifest key where a "system" key is expected