### PR TITLE
Fixed #193

### DIFF
--- a/scripts/modules/OpenWounds.js
+++ b/scripts/modules/OpenWounds.js
@@ -51,7 +51,7 @@ export class OpenWounds {
 
     static _preUpdateActor(actor, update) {
         let hp = getProperty(update, "data.attributes.hp.value");
-        if ((MODULE.setting('OpenWound0HP')) && (hp === 0)) {
+        if ((MODULE.setting('OpenWound0HP')) && (hp <= 0)) {
             OpenWounds.OpenWounds(actor, MODULE.localize("DND5EH.OpenWound0HP_reason"))
         }
     }


### PR DESCRIPTION
Open wounds at 0HP will accept negative HP values from 'Negative HP' module as 'going to 0 HP'