### PR TITLE
Fixed #195

### DIFF
--- a/scripts/modules/ActionManagement.js
+++ b/scripts/modules/ActionManagement.js
@@ -195,7 +195,7 @@ export class ActionManagement{
       ActionManagement._renderActionContainer(tokenDocument.object, mode === 3 || !tokenDocument.object._controlled ? false : true );
     }
 
-    if("tint" in update || "img" in update || "flags" in update)
+    if("tint" in update || "img" in update || !!getProperty(update, `flags.${MODULE.data.name}`))
       tokenDocument.object.updateActionMarkers();
       
     logger.debug("_updateToken | Data | ", {


### PR DESCRIPTION
was rerendering action hud whenever flags existed in the update. Now only does so when a 5e helpers flag is in an update.