### PR TITLE
Issues/212

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -75,15 +75,16 @@ export class MODULE{
     /* null docs could mean an empty lookup, null docs are not owned by anyone */
     if (!doc) return false;
 
-    const gmOwners = Object.entries(doc.data.permission)
-      .filter(([id,level]) => (game.users.get(id)?.isGM && game.users.get(id)?.active) && level === 3)
-      .map(([id, level]) => id);
-    const otherOwners = Object.entries(doc.data.permission)
+    const playerOwners = Object.entries(doc.data.permission)
       .filter(([id, level]) => (!game.users.get(id)?.isGM && game.users.get(id)?.active) && level === 3)
       .map(([id, level])=> id);
 
-    if(otherOwners.length > 0) return game.users.get(otherOwners[0]);
-    else return game.users.get(gmOwners[0]);
+    if(playerOwners.length > 0) {
+      return game.users.get(playerOwners[0]);
+    }
+
+    /* if no online player owns this actor, fall back to first GM */
+    return MODULE.firstGM();
   }
 
   static isFirstOwner(doc){

--- a/scripts/modules/ActionManagement.js
+++ b/scripts/modules/ActionManagement.js
@@ -93,7 +93,7 @@ export class ActionManagement{
     Hooks.on(`updateCombat`, ActionManagement._updateCombat);
     Hooks.on(`controlToken`, ActionManagement._controlToken);
     Hooks.on(`updateToken`, ActionManagement._updateToken);
-    Hooks.on(`preCreateChatMessage`, ActionManagement._preCreateChatMessage);
+    Hooks.on(`createChatMessage`, ActionManagement._createChatMessage);
     Hooks.on(`deleteCombat`, ActionManagement._deleteCombat);
     Hooks.on(`deleteCombatant`, ActionManagement._deleteCombatant);
     Hooks.on('hoverToken', ActionManagement._hoverToken);
@@ -203,11 +203,13 @@ export class ActionManagement{
     });
   }
 
-  static async _preCreateChatMessage(messageDocument, messageData, /*options, userId*/){
+  static async _createChatMessage(messageDocument, /*options, userId*/){
+    const messageData = messageDocument.data;
+
     const types = Object.keys(MODULE[NAME].default);
     const speaker = messageData.speaker;
 
-    logger.debug("_preCreateChatMessage | DATA | ", {
+    logger.debug("_createChatMessage | DATA | ", {
       types, speaker, messageData,
     });
 
@@ -220,7 +222,7 @@ export class ActionManagement{
 
     const item_id = $(messageData.content).attr("data-item-id");
 
-    logger.debug("_preCreateChatMessage | DATA | ", {
+    logger.debug("_createChatMessage | DATA | ", {
       item_id, token,
     });
 
@@ -228,19 +230,20 @@ export class ActionManagement{
 
     const item = token.actor.items.get(item_id);
 
-    logger.debug("_preCreateChatMessage | DATA | ", {
+    logger.debug("_createChatMessage | DATA | ", {
       item,
     });
 
     if(!item || !types.includes(item.data.data.activation.type)) return;
     let type = item.data.data.activation.type;
+    let cost = item.data.data.activation.cost ?? 1;
     
-    logger.debug("_preCreateChatMessage | DATA | ", {
+    logger.debug("_createChatMessage | DATA | ", {
       type,
     });
 
     type = ActionManagement._checkForReaction(type, token.combatant);
-    token.object.iterateActionFlag(type);
+    token.object.iterateActionFlag(type, cost);
   }
 
   static _checkForReaction(actionType, combatant){


### PR DESCRIPTION
**Fixed logical flow of using actions** 

If the non first owner uses an item, it is now processed correctly
Swapped hook of preCreateChat... to createChat... so that the first owner can correctly modify the action state based on the message
The cost is now read from the activation type, which restores the ability to configure 'Action Surge' as '-1 Action' in order to restore its use.

**Modified firstOwner()** 

will now fall back to first online GM in the case of the primary player owner being offline.
Closes #212