### PR TITLE
Undead Fortitude roll check fail safe

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -148,6 +148,8 @@
     "DND5EH.UndeadFort_insantdeathmessage":"{tokenName} dies outright.",
     "DND5EH.UndeadFort_deathmessage":"{tokenName} dies as it rolls a {total}.",
     "DND5EH.UndeadFort_surivalmessage":"{tokenName} survives with a {total}.",
+    "DND5EH.UndeadFort_failsafe":"{tokenName} rolls against DC {dc}",
+
     "DND5EH.UndeadFort_slowdialogcontentquery" : "Damage to target:",
 
     "setting.lairActionHelper.name" : "Lair Action Prompt",

--- a/lang/es.json
+++ b/lang/es.json
@@ -148,6 +148,7 @@
     "DND5EH.UndeadFort_insantdeathmessage":"El objetivo muere directamente",
     "DND5EH.UndeadFort_deathmessage":"{tokenName} muere tras sacar un {total}",
     "DND5EH.UndeadFort_surivalmessage":"{tokenName} sobrevive con un {total}",
+    "DND5EH.UndeadFort_failsafe":"[EN]{tokenName} rolls against DC {dc}",
     "DND5EH.UndeadFort_slowdialogcontentquery" : "Daño al objetivo:",
 
     "setting.lairActionHelper.name" : "[EN] Lair Action Prompt",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -148,6 +148,7 @@
     "DND5EH.UndeadFort_insantdeathmessage":"La cible meurt carrément",
     "DND5EH.UndeadFort_deathmessage":"{tokenName} meurt avec un jet de {total}",
     "DND5EH.UndeadFort_surivalmessage":"{tokenName} survit avec un jet de {total}",
+    "DND5EH.UndeadFort_failsafe":"[EN]{tokenName} rolls against DC {dc}",
     "DND5EH.UndeadFort_slowdialogcontentquery" : "Dégâts sur la cible:",
 
     "setting.lairActionHelper.name" : "[EN] Lair Action Prompt",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -148,6 +148,7 @@
     "DND5EH.UndeadFort_insantdeathmessage":"対象は即座に破壊されます。",
     "DND5EH.UndeadFort_deathmessage":"{tokenName}はセーヴ値：{total}で破壊されました。",
     "DND5EH.UndeadFort_surivalmessage":"{tokenName}はセーヴ値：{total}で生き延びました。",
+    "DND5EH.UndeadFort_failsafe":"[EN]{tokenName} rolls against DC {dc}",
     "DND5EH.UndeadFort_slowdialogcontentquery" : "対象へのダメージ：",
 
     "setting.lairActionHelper.name":"住処アクションの通知",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -148,6 +148,7 @@
     "DND5EH.UndeadFort_insantdeathmessage":"대상이 완전히 소멸했습니다.",
     "DND5EH.UndeadFort_deathmessage":"{tokenName} 대상이 {total}만큼을 굴려 사망했습니다.",
     "DND5EH.UndeadFort_surivalmessage":"{tokenName} 대상이 {total}만큼을 굴려 생존했습니다.",
+    "DND5EH.UndeadFort_failsafe":"[EN]{tokenName} rolls against DC {dc}",
     "DND5EH.UndeadFort_slowdialogcontentquery" : "대상에 대한 피해:",
   
     "setting.lairActionHelper.name" : "소굴 행동 출력",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -148,6 +148,7 @@
     "DND5EH.UndeadFort_insantdeathmessage":"O alvo morre imediatamente",
     "DND5EH.UndeadFort_deathmessage":"{tokenName} morre ao falhar com {total}",
     "DND5EH.UndeadFort_surivalmessage":"{tokenName} sobrevive com {total}",
+    "DND5EH.UndeadFort_failsafe":"[EN]{tokenName} rolls against DC {dc}",
     "DND5EH.UndeadFort_slowdialogcontentquery" : "Dano no alvo:",
 
     "setting.lairActionHelper.name" : "[EN] Lair Action Prompt",


### PR DESCRIPTION
- Added translation string for BR undead fort: DND5EH.UndeadFort_failsafe
- Undead Fort checks with undefined output: For rolling modules that change the output significantly, such as Better Rolls. When a con save is performed but the roll result is not parsed correctly, Helpers will default to whispering the needed save DC to the GM after rolling the save.

Closes #208