### PR TITLE
Added ability to ignore differing levels of cover while providing backwards compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Little helpers for little 5e tasks.
 
 - To enable, select a Surge option from the Feature Helpers config tab and then set the special trait for actors that should surge on casting a spell.
 
-![HelpersSpecialTraits](.github/helpers_special_traits.webp)
+![Special traits](https://user-images.githubusercontent.com/62909799/158481682-550e9ebe-992a-412f-a957-b1fb24dad992.jpg)
 
 - Triggers on _any_ reduction in current spell slots from a character with the 'Wild Magic Surge' special trait
 - Optional homebrews

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ https://user-images.githubusercontent.com/14878515/131264330-7cc644e9-a991-41cb-
 - Automatic will automatically apply the relevant effect but still generate the chat message for manual adjustment.
 - This cover bonus is applied onto the _attacker_ not the target and is a -2,-5,-40 penalty for any attack rolls.
 - The cover bonus to Dexerity saves are not handled.
-- A new special trait has been added to indicate if the actor should ignore cover (e.g. Sharpshooter or Spell Sniper)
-- Alternatively, a flag of `"dnd5e", "helpersIgnoreCover"` will flags the token as ignoring cover, for use with Spell Sniper or Sharpshooter ( will also remove melee cover effects ).
+- A new special trait has been added to indicate if the actor should ignore certain levels of cover (e.g. Sharpshooter, Spell Sniper, Wand of the Warmage)
+- Alternatively, a flag of `"dnd5e", "helpersIgnoreCover"` will flags the token as ignoring cover, for use with Spell Sniper or Sharpshooter ( will also remove melee cover effects ). Said flags accepts values of 0,1,2 or 3 which allows the actor to ignore no, half, three-quarters or full cover respectively. To ensure legacy compatibility values of true are also accepted but identical in functionality to a value of 2.
 - Cover penalties can be optionally removed at the end of the token's turn.
 
 ![Cover Report](.github/cover-report.webp)

--- a/lang/en.json
+++ b/lang/en.json
@@ -29,8 +29,13 @@
     "setting.effectIconScale.name": "Status Effect Scale",
     "setting.effectIconScale.hint": "Multiplier applied to the default icon size of 20px",
 
-    "DND5EH.flagsNoCover" : "Ignore half and three-quarters cover",
-    "DND5EH.flagsNoCoverHint" : "Provided by feats.",
+    "DND5EH.flagsNoCover" : "Ignore certain levels of cover",
+    "DND5EH.flagsNoCoverHint" : "Provided by feats and magic items.",
+    "DND5EH.flagsNoCoverOptionNone" : "Don't ignore any cover.",
+    "DND5EH.flagsNoCoverOptionHalf" : "Ignore half cover.",
+    "DND5EH.flagsNoCoverOptionThreeQ" : "Ignore half and three-quarters cover.",
+    "DND5EH.flagsNoCoverOptionFull" : "Ignore all cover.",
+
     "DND5EH.flagsWildMagic" : "Wild Magic Surge",
     "DND5EH.flagsWildMagicHint" : "Enables wild magic surge automation",
 


### PR DESCRIPTION
Adjusted flag to allow for specification of which level of cover should be ignored as per this issue: https://github.com/trioderegion/dnd5e-helpers/issues/240
Turned setting on actor under special traits from a boolean to a number value with a  dropdown list to archieve this.
Ensured that flags set as true or "true" are read the same as before, as ignoring three-quarters cover and half cover to ensure backwards compatibility.