### PR TITLE
Adds undead fortitude actor flag under special traits

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -177,6 +177,9 @@
     "DND5EH.UndeadFort_failsafe":"{tokenName} rolls against DC {dc}",
     "DND5EH.UndeadFort_slowdialogcontentquery" : "Damage to target:",
 
+    "DND5EH.flagsUndeadFortitude":"Undead Fortitude Equivalent",
+    "DND5EH.flagsUndeadFortitudeHint":"Grants the actor the effects of Undead Fortitude even if they do not have the relevant feature.",
+
     "setting.lairActionHelper.name" : "Lair Action Prompt",
     "setting.lairActionHelper.hint" : "Prompts GM for lair actions at initiative count 20, draws from active combatants",
     "setting.legendaryActionHelper.name" : "Legendary Action Prompt",


### PR DESCRIPTION
Adds flag to actor under the special traits menu to give them the effects of undead fortitude even if they do not have the feature

Fixed a bug that linked actor who were eligible for undead fortitude checks (either by the relevant feature or the newly introduced flag) would cause the saving throw check to fail due to the message referring to the token's name. A fall back to the actor's name has been introduced instead

Closes #261