### PR TITLE
Wild Magic: Surges build up

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -95,6 +95,7 @@
     "option.wmOptions.standard": "Standard (PHB)",
     "option.wmOptions.more": "More Surges",
     "option.wmOptions.volatile": "Volatile Surges",
+    "option.wmOptions.buildup": "Surges build up",
 
     "setting.wmRollMode.name": "Table Roll Mode",
     "setting.wmRollMode.hint": "Default uses the client's current roll mode.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -95,6 +95,7 @@
     "option.wmOptions.standard": "Activé - Standard (MdJ)",
     "option.wmOptions.more": "Activé - Plus",
     "option.wmOptions.volatile": "Activé - Volatile",
+    "option.wmOptions.buildup": "Activé - Accumulation",
 
     "setting.wmRollMode.name": "Table Roll Mode",
     "setting.wmRollMode.hint": "Default uses the client's current roll mode.",

--- a/scripts/plugins/wild-magic-surge.js
+++ b/scripts/plugins/wild-magic-surge.js
@@ -1,3 +1,5 @@
+import {MODULE} from "../module.js"
+
 /**
  * Implements stock surge rules, and two homebrew variants. "More Surges" will surge if the
  * d20 is less than or equal to the spell level cast. "Volatile Surges" will add a d4 to the
@@ -19,6 +21,7 @@ class WildMagicSurge {
       /* use our modified inputs for the homebrew variants */
       WildMagic.registerHandler(game.i18n.localize("option.wmOptions.more"), WildMagicSurge.moreHandler);
       WildMagic.registerHandler(game.i18n.localize("option.wmOptions.volatile"), WildMagicSurge.volatileHandler);
+      WildMagic.registerHandler(game.i18n.localize("option.wmOptions.buildup"), WildMagicSurge.buildupHandler);
     });
   }
 
@@ -38,6 +41,16 @@ class WildMagicSurge {
 
 
     return WildMagic.templates.handler(actor, surgeData, targetRoll);
+  }
+  
+  /* surges on 1d20 <= (number of spells since the last surge + 1) */
+  static async buildupHandler(actor, surgeData) {
+    const targetRoll = actor.getFlag(MODULE.data.name, 'wildMagicBuildupThreshold') ?? 1;
+    
+    let surgeResult = await WildMagic.templates.handler(actor, surgeData, `${targetRoll}`);
+    actor.setFlag(MODULE.data.name, 'wildMagicBuildupThreshold', surgeResult.table ? 1 : targetRoll + 1);
+
+    return surgeResult;
   }
 }
 


### PR DESCRIPTION
Added an homebrew surge mode, where every spell increases the likelihood of a surge occurring.

Note: labels for the special traits seem to be broken, but it's not related to this PR.

![image](https://user-images.githubusercontent.com/33416926/181898079-6fdad996-a2de-4701-bd94-27f4535f0609.png)
